### PR TITLE
Fix to use non-nested parameters for datadog_event operator

### DIFF
--- a/examples/events.dig
+++ b/examples/events.dig
@@ -1,17 +1,17 @@
 _export:
   plugin:
-#   Uncomment this if you try local development.
-#    repositories:
-#      - file:///<your_home_directory>/.m2/repository/
+    repositories:
+      # Uncomment this if you testing the plugin published to local environment.
+      # And then you running `digdag run --no-save --param home=$HOME events.dig`
+      - file://${home}/.m2/repository/
     dependencies:
-      - dev.nomadblacky:digdag-plugin-datadog_2.13:0.3.0
+      - dev.nomadblacky:digdag-plugin-datadog_2.13:0.3.1-SNAPSHOT
 
 +example:
   datadog_event>:
-    title: "[TEST] digdag-plugin-datadog"
-    text: "Digdag meets Datadog!!"
-    tags:
-      - "project:digdag-plugin-datadog"
-      - "env:test"
-    alert_type: info # is default. success, warning or error
-    priority: normal # is default. or low
+  title: "[TEST] digdag-plugin-datadog"
+  text: "Digdag meets Datadog!!"
+  tags:
+    - "env:test"
+  alert_type: info # is default. success, warning or error
+  priority: normal # is default. or low

--- a/src/main/scala/dev/nomadblacky/digdag/plugin/datadog/operator/event/DatadogEventOperator.scala
+++ b/src/main/scala/dev/nomadblacky/digdag/plugin/datadog/operator/event/DatadogEventOperator.scala
@@ -27,7 +27,7 @@ private[operator] class DatadogEventOperator(
     logger.info(s"Start the ${DatadogEventOperator.Name} operation.")
 
     val operationT = for {
-      params    <- Try(request.getConfig.getNested("_command"))
+      params    <- Try(request.getConfig)
       _         = logger.debug(params.toString)
       eventsApi <- clientFactory.newClient(context.getSecrets).toTry
       response  <- postEvent(eventsApi, params)

--- a/src/test/scala/dev/nomadblacky/digdag/plugin/datadog/operator/DatadogEventOperatorTest.scala
+++ b/src/test/scala/dev/nomadblacky/digdag/plugin/datadog/operator/DatadogEventOperatorTest.scala
@@ -14,21 +14,17 @@ class DatadogEventOperatorTest extends DigdagSpec {
   describe("runTask") {
 
     def requiredParams = ujson.Obj(
-      "_command" -> ujson.Obj(
-        "title" -> "TITLE",
-        "text"  -> "TEXT"
-      )
+      "title" -> "TITLE",
+      "text"  -> "TEXT"
     )
 
     describe("when required params is set") {
       describe("when operation is succeeded") {
         val params = ujson.Obj(
-          "_command" -> ujson.Obj(
-            "title"      -> "TITLE",
-            "text"       -> "TEXT",
-            "tags"       -> ujson.Arr("env:test"),
-            "alert_type" -> "success"
-          )
+          "title"      -> "TITLE",
+          "text"       -> "TEXT",
+          "tags"       -> ujson.Arr("env:test"),
+          "alert_type" -> "success"
         )
         val (request, context) = newContext(newConfig(params))
         val client             = spy(new EventsAPIClientForTest)
@@ -88,7 +84,7 @@ class DatadogEventOperatorTest extends DigdagSpec {
     describe("when invalid params is set") {
       it("throws a TaskExecutionException when `title` is missing") {
         val params = requiredParams
-        params.obj("_command").obj.remove("title")
+        params.obj.remove("title")
         val (_, context) = newContext(newConfig(params))
         val operator     = new DatadogEventOperator(context, new EventsAPIClientFactoryForTest)
 
@@ -97,7 +93,7 @@ class DatadogEventOperatorTest extends DigdagSpec {
 
       it("throws a TaskExecutionException when `text` is missing") {
         val params = requiredParams
-        params.obj("_command").obj.remove("text")
+        params.obj.remove("text")
         val (_, context) = newContext(newConfig(params))
         val operator     = new DatadogEventOperator(context, new EventsAPIClientFactoryForTest)
 
@@ -106,7 +102,7 @@ class DatadogEventOperatorTest extends DigdagSpec {
 
       it("throws a TaskExecutionException when `alert_type` is invalid") {
         val params = requiredParams
-        params.obj("_command").obj("alert_type") = "foo"
+        params.obj("alert_type") = "foo"
         val (_, context) = newContext(newConfig(params))
         val operator     = new DatadogEventOperator(context, new EventsAPIClientFactoryForTest)
 
@@ -115,7 +111,7 @@ class DatadogEventOperatorTest extends DigdagSpec {
 
       it("throws a TaskExecutionException when `priority` is invalid") {
         val params = requiredParams
-        params.obj("_command").obj("priority") = "foo"
+        params.obj("priority") = "foo"
         val (_, context) = newContext(newConfig(params))
         val operator     = new DatadogEventOperator(context, new EventsAPIClientFactoryForTest)
 


### PR DESCRIPTION
Typical operators are using non-nested parameters.
But `datadog_event` operator is using nested parameters.

```
+simple_query_nonexpanded:
  td>:
  # non-nested
  query: "SELECT * FROM nasdaq"

+example:
  datadog_event>:
    # nested
    title: "[TEST] digdag-plugin-datadog"
    text: "Digdag meets Datadog!!"
    tags:
      - "env:test"
    alert_type: info # is default. success, warning or error
    priority: normal # is default. or low
```

I think should use non-nested parameters making no misleading.
However, I prefer nested parameters because logs are more clear.

## Before

```
digdag run --no-save --param home=$HOME events.dig
2020-03-07 18:01:59 +0900: Digdag v0.9.41
2020-03-07 18:02:00 +0900 [WARN] (main): Using a new session time 2020-03-07T00:00:00+00:00.
2020-03-07 18:02:00 +0900 [INFO] (main): Starting a new session project id=1 workflow name=events session_time=2020-03-07T00:00:00+00:00
2020-03-07 18:02:01 +0900 [INFO] (0016@[0:default]+events+example): datadog_event>: {title=[TEST] digdag-plugin-datadog, text=Digdag meets Datadog!!, tags=[env:test], alert_type=info, priority=normal}
2020-03-07 18:02:05 +0900 [INFO] (0016@[0:default]+events+example): Start the datadog_event operation.
2020-03-07 18:02:06 +0900 [INFO] (0016@[0:default]+events+example): Succeeded to post the event to Datadog. https://app.datadoghq.com/event/event?id=5357113725809002349
Success.
```

## After

```
$ digdag run --no-save --param home=$HOME events.dig
2020-03-07 18:03:50 +0900: Digdag v0.9.41
2020-03-07 18:03:54 +0900 [WARN] (main): Using a new session time 2020-03-07T00:00:00+00:00.
2020-03-07 18:03:54 +0900 [INFO] (main): Starting a new session project id=1 workflow name=events session_time=2020-03-07T00:00:00+00:00
2020-03-07 18:03:55 +0900 [INFO] (0016@[0:default]+events+example): datadog_event>:
2020-03-07 18:03:57 +0900 [INFO] (0016@[0:default]+events+example): Start the datadog_event operation.
2020-03-07 18:04:00 +0900 [INFO] (0016@[0:default]+events+example): Succeeded to post the event to Datadog. https://app.datadoghq.com/event/event?id=5357115636173312813
Success.
```